### PR TITLE
Add Flask chat client for Ollama

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# ai-chat
+# AI Chat
+
+This is a simple Flask web application that connects to an Ollama server to provide an AI chat using the **mistral** model.
+
+## Requirements
+
+- Python 3
+- Flask
+- requests
+
+## Running
+
+Use the provided `run.sh` script to set up a virtual environment, install dependencies and start the server:
+
+```bash
+./run.sh
+```
+
+By default the application expects an Ollama server running at `http://127.0.0.1:11434`.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,42 @@
+from flask import Flask, request, render_template, session, redirect, url_for
+import requests
+
+app = Flask(__name__)
+app.secret_key = "change-me"
+
+OLLAMA_API = "http://127.0.0.1:11434/api/chat"
+MODEL_NAME = "mistral"
+
+
+def query_ollama(history):
+    payload = {
+        "model": MODEL_NAME,
+        "messages": history,
+        "stream": False
+    }
+    response = requests.post(OLLAMA_API, json=payload, timeout=60)
+    response.raise_for_status()
+    data = response.json()
+    message = data.get("message", {})
+    return message.get("content", "")
+
+
+@app.route('/', methods=['GET', 'POST'])
+def chat():
+    if 'history' not in session:
+        session['history'] = []
+    if request.method == 'POST':
+        text = request.form.get('message', '').strip()
+        if text:
+            session['history'].append({"role": "user", "content": text})
+            try:
+                reply = query_ollama(session['history'])
+            except Exception as exc:
+                reply = f"Error: {exc}"
+            session['history'].append({"role": "assistant", "content": reply})
+        return redirect(url_for('chat'))
+    return render_template('chat.html', history=session['history'])
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+requests

--- a/run.sh
+++ b/run.sh
@@ -2,4 +2,4 @@
 python3 -m venv venv
 source venv/bin/activate
 pip3 install -r requirements.txt
-python app.py
+python3 app.py

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>AI Chat</title>
+  </head>
+  <body>
+    <h1>AI Chat</h1>
+    <div id="chat">
+      {% for msg in history %}
+        <p><strong>{{ msg.role }}:</strong> {{ msg.content }}</p>
+      {% endfor %}
+    </div>
+    <form method="post">
+      <input type="text" name="message" autofocus required>
+      <input type="submit" value="Send">
+    </form>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a simple Flask app that chats with Ollama using the `mistral` model
- describe usage in README
- add requirements file and update run script
- provide basic HTML template for the chat interface

## Testing
- `pytest -q`