### PR TITLE
Add standalone frontend for Ollama

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,7 @@ python3 gui.py
 
 The GUI communicates with the same Ollama server and displays the conversation
 in a scrollable window.
+
+## Standalone Frontend Example
+
+A very minimal HTML page that communicates directly with the Ollama API is included as `simple_frontend.html`. You can open this file in your browser (no server required) while the Ollama server is running. The page sends requests to `http://127.0.0.1:11434/api/chat` and displays the conversation locally.

--- a/simple_frontend.html
+++ b/simple_frontend.html
@@ -1,0 +1,61 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Simple Ollama Frontend</title>
+    <style>
+        #conversation { height: 300px; overflow-y: auto; border: 1px solid #ccc; padding: 0.5em; }
+        #conversation p { margin: 0 0 0.5em; }
+    </style>
+</head>
+<body>
+    <h1>Ollama Frontend</h1>
+    <div id="conversation"></div>
+    <form id="form">
+        <input id="message" autocomplete="off" required>
+        <button type="submit">Send</button>
+    </form>
+    <script>
+        const API_URL = 'http://127.0.0.1:11434/api/chat';
+        const MODEL = 'mistral';
+        const history = [];
+
+        async function send(e) {
+            e.preventDefault();
+            const input = document.getElementById('message');
+            const text = input.value.trim();
+            if (!text) return;
+            input.value = '';
+            history.push({role: 'user', content: text});
+            update();
+            const payload = {model: MODEL, messages: history, stream: false};
+            try {
+                const resp = await fetch(API_URL, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(payload)
+                });
+                const data = await resp.json();
+                const reply = (data.message && data.message.content) || '';
+                history.push({role: 'assistant', content: reply});
+            } catch (err) {
+                history.push({role: 'assistant', content: 'Error: ' + err});
+            }
+            update();
+        }
+
+        function update() {
+            const div = document.getElementById('conversation');
+            div.innerHTML = '';
+            for (const m of history) {
+                const p = document.createElement('p');
+                p.innerHTML = '<strong>' + m.role + ':</strong> ' + m.content;
+                div.appendChild(p);
+            }
+            div.scrollTop = div.scrollHeight;
+        }
+
+        document.getElementById('form').addEventListener('submit', send);
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create `simple_frontend.html` with a basic conversation UI
- document the standalone frontend in the README

## Testing
- `python3 -m py_compile app.py gui.py`