### PR TITLE
Add navigation menu linking pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,4 +32,4 @@ in a scrollable window.
 
 ## Standalone Frontend Example
 
-A very minimal HTML page that communicates directly with the Ollama API is included as `simple_frontend.html`. You can open this file in your browser (no server required) while the Ollama server is running. The page sends requests to `http://127.0.0.1:11434/api/chat` and displays the conversation locally.
+A very minimal HTML page that communicates directly with the Ollama API is included as `simple_frontend.html`. It is now also served by the Flask app at `/simple`, and a navigation menu links to it from the main chat page. You can open this file directly in your browser (no server required) or access it through the running Flask application. The page sends requests to `http://127.0.0.1:11434/api/chat` and displays the conversation locally.

--- a/app.py
+++ b/app.py
@@ -1,4 +1,4 @@
-from flask import Flask, request, render_template, session, jsonify
+from flask import Flask, request, render_template, session, jsonify, send_file
 import requests
 
 app = Flask(__name__)
@@ -42,6 +42,12 @@ def chat():
                 reply = f'Error: {exc}'
             session['history'].append({'role': 'assistant', 'content': reply})
     return jsonify(history=session['history'])
+
+
+@app.route('/simple')
+def simple_frontend():
+    """Serve the standalone simple frontend page."""
+    return send_file('simple_frontend.html')
 
 
 if __name__ == '__main__':

--- a/simple_frontend.html
+++ b/simple_frontend.html
@@ -9,6 +9,10 @@
     </style>
 </head>
 <body>
+    <nav>
+        <a href="/">Flask Chat</a> |
+        <a href="/simple">Simple Frontend</a>
+    </nav>
     <h1>Ollama Frontend</h1>
     <div id="conversation"></div>
     <form id="form">

--- a/templates/index.html
+++ b/templates/index.html
@@ -9,6 +9,10 @@
     </style>
 </head>
 <body>
+    <nav>
+        <a href="/">Flask Chat</a> |
+        <a href="/simple">Simple Frontend</a>
+    </nav>
     <h1>Ollama Chat</h1>
     <div id="conversation">
         {% for m in history %}


### PR DESCRIPTION
## Summary
- link the Flask chat page and standalone frontend with a simple nav menu
- serve `simple_frontend.html` at `/simple`
- mention the new route in the README

## Testing
- `python3 -m py_compile app.py gui.py`
