### PR TITLE
Add SQLite persistence for simple frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,4 +32,4 @@ in a scrollable window.
 
 ## Standalone Frontend Example
 
-A very minimal HTML page that communicates directly with the Ollama API is included as `simple_frontend.html`. It is now also served by the Flask app at `/simple`, and a navigation menu links to it from the main chat page. You can open this file directly in your browser (no server required) or access it through the running Flask application. The page sends requests to `http://127.0.0.1:11434/api/chat` and displays the conversation locally.
+A very minimal HTML page is included as `simple_frontend.html` and served by the Flask app at `/simple`. When used through the Flask server the conversation is persisted in a local SQLite database. The page communicates with the endpoints `/simple/chat` and `/simple/history` provided by the application.

--- a/app.py
+++ b/app.py
@@ -1,11 +1,43 @@
 from flask import Flask, request, render_template, session, jsonify, send_file
 import requests
+import sqlite3
 
 app = Flask(__name__)
 app.config['SECRET_KEY'] = 'change-me'
 
 OLLAMA_URL = 'http://127.0.0.1:11434/api/chat'
 MODEL = 'mistral'
+DB_PATH = 'chat_history.db'
+
+
+def init_db():
+    """Ensure that the SQLite database and table exist."""
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
+    c.execute(
+        'CREATE TABLE IF NOT EXISTS messages (id INTEGER PRIMARY KEY AUTOINCREMENT, role TEXT, content TEXT)'
+    )
+    conn.commit()
+    conn.close()
+
+
+def get_history():
+    """Return the full conversation history from the database."""
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
+    c.execute('SELECT role, content FROM messages ORDER BY id')
+    rows = c.fetchall()
+    conn.close()
+    return [{'role': r, 'content': m} for r, m in rows]
+
+
+def add_message(role, content):
+    """Insert a single message into the database."""
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
+    c.execute('INSERT INTO messages (role, content) VALUES (?, ?)', (role, content))
+    conn.commit()
+    conn.close()
 
 
 def call_ollama(messages):
@@ -50,5 +82,28 @@ def simple_frontend():
     return send_file('simple_frontend.html')
 
 
+@app.route('/simple/history')
+def simple_history():
+    """Return conversation history stored in the database."""
+    return jsonify(history=get_history())
+
+
+@app.route('/simple/chat', methods=['POST'])
+def simple_chat_api():
+    """Handle chat messages for the simple frontend using persistent storage."""
+    data = request.get_json(silent=True) or {}
+    text = data.get('message', '').strip()
+    if text:
+        add_message('user', text)
+        history = get_history()
+        try:
+            reply = call_ollama(history)
+        except Exception as exc:
+            reply = f'Error: {exc}'
+        add_message('assistant', reply)
+    return jsonify(history=get_history())
+
+
 if __name__ == '__main__':
+    init_db()
     app.run(debug=True)

--- a/simple_frontend.html
+++ b/simple_frontend.html
@@ -20,9 +20,16 @@
         <button type="submit">Send</button>
     </form>
     <script>
-        const API_URL = 'http://127.0.0.1:11434/api/chat';
-        const MODEL = 'mistral';
-        const history = [];
+        const CHAT_URL = '/simple/chat';
+        const HISTORY_URL = '/simple/history';
+        let history = [];
+
+        async function loadHistory() {
+            const resp = await fetch(HISTORY_URL);
+            const data = await resp.json();
+            history = data.history;
+            update();
+        }
 
         async function send(e) {
             e.preventDefault();
@@ -30,18 +37,14 @@
             const text = input.value.trim();
             if (!text) return;
             input.value = '';
-            history.push({role: 'user', content: text});
-            update();
-            const payload = {model: MODEL, messages: history, stream: false};
             try {
-                const resp = await fetch(API_URL, {
+                const resp = await fetch(CHAT_URL, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify(payload)
+                    body: JSON.stringify({message: text})
                 });
                 const data = await resp.json();
-                const reply = (data.message && data.message.content) || '';
-                history.push({role: 'assistant', content: reply});
+                history = data.history;
             } catch (err) {
                 history.push({role: 'assistant', content: 'Error: ' + err});
             }
@@ -60,6 +63,7 @@
         }
 
         document.getElementById('form').addEventListener('submit', send);
+        loadHistory();
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- persist simple frontend conversation history in `chat_history.db`
- expose `/simple/history` and `/simple/chat` API endpoints
- load conversation history in `simple_frontend.html`
- document the new behaviour in README

## Testing
- `python3 -m py_compile app.py gui.py`