### PR TITLE
Add multi-chat support to simple frontend

### DIFF
--- a/simple_frontend.html
+++ b/simple_frontend.html
@@ -14,6 +14,7 @@
         <a href="/simple">Simple Frontend</a>
     </nav>
     <h1>Ollama Frontend</h1>
+    <button id="new-chat" type="button">Nowy chat</button>
     <div id="conversation"></div>
     <form id="form">
         <input id="message" autocomplete="off" required>
@@ -23,9 +24,22 @@
         const CHAT_URL = '/simple/chat';
         const HISTORY_URL = '/simple/history';
         let history = [];
+        let chatId = localStorage.getItem('chatId') || generateId();
+        localStorage.setItem('chatId', chatId);
+
+        function generateId() {
+            return Date.now().toString(36) + Math.random().toString(36).substring(2, 8);
+        }
+
+        function newChat() {
+            chatId = generateId();
+            localStorage.setItem('chatId', chatId);
+            history = [];
+            update();
+        }
 
         async function loadHistory() {
-            const resp = await fetch(HISTORY_URL);
+            const resp = await fetch(HISTORY_URL + '?chat_id=' + encodeURIComponent(chatId));
             const data = await resp.json();
             history = data.history;
             update();
@@ -38,7 +52,7 @@
             if (!text) return;
             input.value = '';
             try {
-                const resp = await fetch(CHAT_URL, {
+                const resp = await fetch(CHAT_URL + '?chat_id=' + encodeURIComponent(chatId), {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({message: text})
@@ -63,6 +77,10 @@
         }
 
         document.getElementById('form').addEventListener('submit', send);
+        document.getElementById('new-chat').addEventListener('click', function() {
+            newChat();
+            loadHistory();
+        });
         loadHistory();
     </script>
 </body>


### PR DESCRIPTION
## Summary
- extend database schema with `chat_id`
- add helper functions to store/retrieve history for a chat
- update simple frontend API handlers to use `chat_id`
- add 'Nowy chat' button in the simple frontend to start new conversations

## Testing
- `python3 -m py_compile app.py gui.py`