### PR TITLE
Add multi-chat support to simple frontend

### DIFF
--- a/app.py
+++ b/app.py
@@ -15,27 +15,27 @@ def init_db():
     conn = sqlite3.connect(DB_PATH)
     c = conn.cursor()
     c.execute(
-        'CREATE TABLE IF NOT EXISTS messages (id INTEGER PRIMARY KEY AUTOINCREMENT, role TEXT, content TEXT)'
+        'CREATE TABLE IF NOT EXISTS messages (id INTEGER PRIMARY KEY AUTOINCREMENT, chat_id TEXT, role TEXT, content TEXT)'
     )
     conn.commit()
     conn.close()
 
 
-def get_history():
-    """Return the full conversation history from the database."""
+def get_history(chat_id='default'):
+    """Return the full conversation history for a given chat id from the database."""
     conn = sqlite3.connect(DB_PATH)
     c = conn.cursor()
-    c.execute('SELECT role, content FROM messages ORDER BY id')
+    c.execute('SELECT role, content FROM messages WHERE chat_id=? ORDER BY id', (chat_id,))
     rows = c.fetchall()
     conn.close()
     return [{'role': r, 'content': m} for r, m in rows]
 
 
-def add_message(role, content):
-    """Insert a single message into the database."""
+def add_message(chat_id, role, content):
+    """Insert a single message into the database for a given chat."""
     conn = sqlite3.connect(DB_PATH)
     c = conn.cursor()
-    c.execute('INSERT INTO messages (role, content) VALUES (?, ?)', (role, content))
+    c.execute('INSERT INTO messages (chat_id, role, content) VALUES (?, ?, ?)', (chat_id, role, content))
     conn.commit()
     conn.close()
 
@@ -85,25 +85,30 @@ def simple_frontend():
 @app.route('/simple/history')
 def simple_history():
     """Return conversation history stored in the database."""
-    return jsonify(history=get_history())
+    chat_id = request.args.get('chat_id', 'default')
+    return jsonify(history=get_history(chat_id))
 
 
 @app.route('/simple/chat', methods=['POST'])
 def simple_chat_api():
     """Handle chat messages for the simple frontend using persistent storage."""
     data = request.get_json(silent=True) or {}
+    chat_id = request.args.get('chat_id', data.get('chat_id', 'default'))
     text = data.get('message', '').strip()
     if text:
-        add_message('user', text)
-        history = get_history()
+        add_message(chat_id, 'user', text)
+        history = get_history(chat_id)
         try:
             reply = call_ollama(history)
         except Exception as exc:
             reply = f'Error: {exc}'
-        add_message('assistant', reply)
-    return jsonify(history=get_history())
+        add_message(chat_id, 'assistant', reply)
+    return jsonify(history=get_history(chat_id))
 
+
+# Initialize the database when the module is imported so that the application
+# works regardless of how it is started (e.g. using ``flask run``).
+init_db()
 
 if __name__ == '__main__':
-    init_db()
     app.run(debug=True)

--- a/simple_frontend.html
+++ b/simple_frontend.html
@@ -14,6 +14,7 @@
         <a href="/simple">Simple Frontend</a>
     </nav>
     <h1>Ollama Frontend</h1>
+    <button id="new-chat" type="button">Nowy chat</button>
     <div id="conversation"></div>
     <form id="form">
         <input id="message" autocomplete="off" required>
@@ -23,9 +24,22 @@
         const CHAT_URL = '/simple/chat';
         const HISTORY_URL = '/simple/history';
         let history = [];
+        let chatId = localStorage.getItem('chatId') || generateId();
+        localStorage.setItem('chatId', chatId);
+
+        function generateId() {
+            return Date.now().toString(36) + Math.random().toString(36).substring(2, 8);
+        }
+
+        function newChat() {
+            chatId = generateId();
+            localStorage.setItem('chatId', chatId);
+            history = [];
+            update();
+        }
 
         async function loadHistory() {
-            const resp = await fetch(HISTORY_URL);
+            const resp = await fetch(HISTORY_URL + '?chat_id=' + encodeURIComponent(chatId));
             const data = await resp.json();
             history = data.history;
             update();
@@ -38,7 +52,7 @@
             if (!text) return;
             input.value = '';
             try {
-                const resp = await fetch(CHAT_URL, {
+                const resp = await fetch(CHAT_URL + '?chat_id=' + encodeURIComponent(chatId), {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({message: text})
@@ -63,6 +77,10 @@
         }
 
         document.getElementById('form').addEventListener('submit', send);
+        document.getElementById('new-chat').addEventListener('click', function() {
+            newChat();
+            loadHistory();
+        });
         loadHistory();
     </script>
 </body>


### PR DESCRIPTION
## Summary
- extend database schema with `chat_id`
- add helper functions to store/retrieve history for a chat
- update simple frontend API handlers to use `chat_id`
- add 'Nowy chat' button in the simple frontend to start new conversations
- initialize the database at import so that running with `flask run` works

## Testing
- `python3 -m py_compile app.py gui.py`
